### PR TITLE
set config.assets.debug to false (default value)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
This returns the value of config.assets.debug to false (default). I had changed it for debug purpose when I was implementing the geocode feature